### PR TITLE
Make spell checker smarter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pkg/*
 .bundle
 .DS_Store
 Gemfile.lock
+.history/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ sudo: required
 before_install: gem update --system
 dist: trusty
 language: ruby
+addons:
+  apt:
+    packages:
+      - aspell
+      - aspell-en
 rvm:
 - 2.0.0
 - 2.1

--- a/README.md
+++ b/README.md
@@ -13,3 +13,30 @@ You'll need to install Aspell:
 
 * Arch Linux: `sudo pacman -S aspell`
 * OS X: (`brew install aspell --lang=en`)
+
+## Configuration
+
+In order to change configuration, you need to create `.pronto_spell.yaml` file in your project root directory. Awailable options are:
+
+```YAML
+suggestion_mode: 'fast' # default
+min_word_length: 5 # default
+max_word_length: 999 # default is Infinity
+max_suggestions_number: 3 # default
+ignored_words: # words in this list won't be marked as misspelled
+  - aspell
+  - boolean
+  - datetime
+```
+
+It's also handy to have `.pronto.yml`. Here is configuration, designed for rails project:
+```YAML
+spell:
+  exclude:
+    - 'yarn.lock'
+    - 'Gemfile.lock'
+    - 'Gemfile'
+    - 'package.json'
+    - '.*.yml'
+    - '*.json'
+```

--- a/lib/pronto/spell.rb
+++ b/lib/pronto/spell.rb
@@ -78,13 +78,16 @@ module Pronto
     end
 
     def misspelled?(word)
-      (5..30).cover?(word.length) &&
-        word !~ /\A\d+/ &&            # "1234", "1050px"
-        !symbol_defined?(word) &&     # "strftime"
+      should_lint_word?(word) &&
+        !symbol_defined?(word) &&
         !speller.correct?(word) &&
         !speller.correct?(word.sub(/(e?s|\d+)\z/, '')) &&
-        !correct_camel_case?(word) && # "AppleOrange"
+        !correct_camel_case?(word) &&
         !whitelist.any? { |regexp| regexp =~ word }
+    end
+
+    def should_lint_word?(word)
+      (5..30).cover?(word.length) && word !~ /\d+/
     end
 
     def should_lint_file?(path)

--- a/lib/pronto/spell.rb
+++ b/lib/pronto/spell.rb
@@ -3,30 +3,58 @@ require 'ffi/aspell'
 
 module Pronto
   class Spell < Runner
-    def run
-      return [] unless @patches
+    CONFIG_FILE = '.pronto_spell.yml'.freeze
+    CONFIG_KEYS = %w(files_to_lint whitelist).freeze
 
-      @patches.select { |patch| patch.additions > 0 }
+    def files_to_lint
+      @files_to_lint || /\.rb$/
+    end
+
+    def files_to_lint=(regexp)
+      @files_to_lint = regexpify(regexp)
+    end
+
+    def whitelist
+      @whitelist || []
+    end
+
+    def whitelist=(array)
+      @whitelist = array.map { |regexp| regexpify(regexp) }
+    end
+
+    def run
+      return [] if !@patches || @patches.count.zero?
+
+      read_config
+
+      @all_symbols = Symbol.all_symbols
+
+      @patches
+        .select { |patch| patch.additions > 0 }
+        .select { |patch| should_lint_file?(patch.new_file_full_path) }
         .map { |patch| inspect(patch) }
         .flatten.compact
     end
 
+    private
+
     def inspect(patch)
       patch.added_lines.map do |line|
         words = line.content.scan(/[0-9a-zA-Z]+/)
-        words.select { |word| word.length > 4 }
+        words.select { |word| (5..30).cover?(word.length) }
           .uniq
-          .select { |word| !speller.correct?(word) }
+          .select { |word| misspelled?(word) }
           .map { |word| new_message(word, line) }
       end
     end
 
     def new_message(word, line)
       path = line.patch.delta.new_file[:path]
-      level = :warning
+      level = :info
 
       suggestions = speller.suggestions(word)
-      msg = "#{word} might not be spelled correctly. Spelling suggestions: #{suggestions}"
+      msg = %("#{word}" might not be spelled correctly.)
+      msg << " Spelling suggestions: #{suggestions[0..2].join(', ')}" unless suggestions.empty?
 
       Message.new(path, line, level, msg, nil, self.class)
     end
@@ -37,6 +65,44 @@ module Pronto
         result.suggestion_mode = 'fast'
         result
       end
+    end
+
+    def read_config
+      config_file = File.join(repo_path, CONFIG_FILE)
+      return unless File.exist?(config_file)
+      config = YAML.load_file(config_file)
+
+      CONFIG_KEYS.each do |config_key|
+        next unless config[config_key]
+        send("#{config_key}=", config[config_key])
+      end
+    end
+
+    def misspelled?(word)
+      word !~ /\A\d+/ &&              # "1234", "1050px"
+        !symbol_defined?(word) &&     # "strftime"
+        !speller.correct?(word) &&
+        !speller.correct?(word.sub(/(e?s|\d+)\z/, '')) &&
+        !correct_camel_case?(word) && # "AppleOrange"
+        !whitelist.any? { |regexp| regexp =~ word }
+    end
+
+    def should_lint_file?(path)
+      files_to_lint =~ path.to_s
+    end
+
+    def correct_camel_case?(word)
+      word = word[0].capitalize + word[1..-1]
+      parts = word.scan(/[A-Z][a-z]+|[A-Z]+(?![a-z])/)
+      parts.size > 1 && parts.none? { |part| misspelled?(part) }
+    end
+
+    def regexpify(regexp)
+      regexp.is_a?(Regexp) ? regexp : Regexp.new(regexp, Regexp::IGNORECASE)
+    end
+
+    def symbol_defined?(symbol)
+      @all_symbols.include?(symbol.to_sym)
     end
   end
 end

--- a/lib/pronto/spell.rb
+++ b/lib/pronto/spell.rb
@@ -41,8 +41,7 @@ module Pronto
     def inspect(patch)
       patch.added_lines.map do |line|
         words = line.content.scan(/[0-9a-zA-Z]+/)
-        words.select { |word| (5..30).cover?(word.length) }
-          .uniq
+        words.uniq
           .select { |word| misspelled?(word) }
           .map { |word| new_message(word, line) }
       end
@@ -79,7 +78,8 @@ module Pronto
     end
 
     def misspelled?(word)
-      word !~ /\A\d+/ &&              # "1234", "1050px"
+      (5..30).cover?(word.length) &&
+        word !~ /\A\d+/ &&            # "1234", "1050px"
         !symbol_defined?(word) &&     # "strftime"
         !speller.correct?(word) &&
         !speller.correct?(word.sub(/(e?s|\d+)\z/, '')) &&

--- a/spec/pronto/spell_spec.rb
+++ b/spec/pronto/spell_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+module Pronto
+  describe Spell do
+    subject(:spell) { described_class.new(patches) }
+
+    let(:patches) { [patch] }
+
+    let(:patch) do
+      double('Patch', additions: 1, added_lines: added_lines)
+    end
+
+    let(:added_lines) do
+      [
+        double(
+          'AddedLine',
+          content: patch_content, patch: line_patch, commit_sha: 'abc23'
+        )
+      ]
+    end
+
+    let(:patch_content) { 'helllo woorld!' }
+    let(:line_patch) { double('LinePatch', delta: line_patch_delta) }
+    let(:line_patch_delta) { double('Delta', new_file: { file_path: 'some/path.txt' }) }
+    let(:spelling_config) { {} }
+
+    before do
+      allow(spell).to receive(:spelling_config).and_return(spelling_config)
+      allow(spell).to receive(:repo_path).and_return('/home/developer/projects/pronto-spell')
+    end
+
+    describe '#run' do
+      subject(:lint_messages) { spell.run.map(&:msg) }
+
+      context 'patches are nil' do
+        let(:patches) { nil }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'no patches' do
+        let(:patches) { [] }
+
+        it { is_expected.to be_empty }
+      end
+
+      context 'with misspelled words' do
+        it 'returns list of misspeled words' do
+          expect(lint_messages).to eq [
+            '"helllo" might not be spelled correctly. ' \
+              'Spelling suggestions: hell lo, hell-lo, hello',
+
+            '"woorld" might not be spelled correctly. ' \
+              'Spelling suggestions: world, wold, whorled'
+          ]
+        end
+      end
+
+      context 'with camel cased words' do
+        let(:patch_content) { 'CamelWithhWrrrongGrammar' }
+
+        it 'validates each word separately' do
+          expect(lint_messages).to eq [
+            '"Withh" might not be spelled correctly. ' \
+              'Spelling suggestions: With, Withe, Wither',
+
+            '"Wrrrong" might not be spelled correctly. ' \
+              'Spelling suggestions: Wrong, Wrung, Wring'
+          ]
+        end
+      end
+
+      context 'with words consisting of capital letters only' do
+        let(:patch_content) { 'LOOOK_AT_ME_I_AM_SHOWTING' }
+
+        it 'validates each word separately' do
+          expect(lint_messages).to eq [
+            '"LOOOK" might not be spelled correctly. ' \
+              'Spelling suggestions: LOO OK, LOO-OK, LOOK',
+
+            '"SHOWTING" might not be spelled correctly. ' \
+              'Spelling suggestions: SHOW TING, SHOW-TING, SHOOTING'
+          ]
+        end
+      end
+
+      context 'with words which contain numbers' do
+        let(:patch_content) { '2coool4skool' }
+
+        it 'lints words and ignores number part' do
+          expect(lint_messages).to eq [
+            '"coool" might not be spelled correctly. '\
+              'Spelling suggestions: cool, Colo, coil',
+
+            '"skool" might not be spelled correctly. '\
+              'Spelling suggestions: skoal, school, skill'
+          ]
+        end
+      end
+
+      context 'with ignored words' do
+        let(:spelling_config) do
+          { 'ignored_words' => ['HaXoR'] }
+        end
+
+        let(:patch_content) { 'it feels good to be a haxor' }
+
+        it 'does not complain about words included in personal dictionary' do
+          expect(lint_messages).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,4 @@ require 'rspec/its'
 require 'pronto/spell'
 
 RSpec.configure do |config|
-  config.expect_with(:rspec) { |c| c.syntax = :should }
-  config.mock_with(:rspec) { |c| c.syntax = :should }
 end


### PR DESCRIPTION
This PR includes multiple improvements which are:
- now it's possible to use custom configuration via `.pronto_spell.yml` file:
  - it's possible to specify minimum and maximum word length;
  - it's possible to specify which words should be ignored;
  - it's possible to specify max suggestions number;
  - it's possible to specify suggestion mode;
  - it's possible to add ignored words;

some changes which changes default behavior:
- now there is a limit for suggestions which is 3;
- camel case words are spitted and linted separately;
- numbers are excluded and only word part is linted;

additional changes:
- added tests, changed tests strategy from should to rspec default which is `expect`

P.S. This PR is based on @zhuravel work, so big thanks for him
P.P.S. fixes #1 