### PR TITLE
Allow more complex yaml structure and fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You'll need to install Aspell:
 
 ## Configuration
 
-In order to change configuration, you need to create `.pronto_spell.yaml` file in your project root directory. Awailable options are:
+In order to change configuration, you need to create `.pronto_spell.yml` file in your project root directory. Awailable options are:
 
 ```YAML
 suggestion_mode: 'fast' # default

--- a/lib/pronto/spell.rb
+++ b/lib/pronto/spell.rb
@@ -9,13 +9,13 @@ module Pronto
 
     def ignored_words
       @ignored_words ||= begin
-        Set.new(spelling_config['ignored_words'].to_a.map(&:downcase))
+        Set.new(spelling_config['ignored_words'].to_a.flatten.map(&:downcase))
       end
     end
 
     def keywords
       @keywords ||= begin
-        Set.new(spelling_config['only_lines_matching'].to_a.map(&:downcase))
+        Set.new(spelling_config['only_lines_matching'].to_a.flatten.map(&:downcase))
       end
     end
 

--- a/lib/pronto/spell/version.rb
+++ b/lib/pronto/spell/version.rb
@@ -2,6 +2,6 @@
 
 module Pronto
   module SpellVersion
-    VERSION = '0.11.0'
+    VERSION = '0.11.1'
   end
 end

--- a/spec/pronto/spell_spec.rb
+++ b/spec/pronto/spell_spec.rb
@@ -50,10 +50,10 @@ module Pronto
       end
 
       context 'with misspelled words' do
-        it 'returns list of misspeled words' do
+        fit 'returns list of misspeled words' do
           expect(lint_messages).to eq [
             '"helllo" might not be spelled correctly. ' \
-              'Spelling suggestions: hell lo, hell-lo, hello',
+              "Spelling suggestions: hello, hell, he'll",
 
             '"woorld" might not be spelled correctly. ' \
               'Spelling suggestions: world, wold, whorled'
@@ -67,7 +67,7 @@ module Pronto
         it 'validates each word separately' do
           expect(lint_messages).to eq [
             '"Withh" might not be spelled correctly. ' \
-              'Spelling suggestions: With, Withe, Wither',
+              'Spelling suggestions: With, Withe, Witch',
 
             '"Wrrrong" might not be spelled correctly. ' \
               'Spelling suggestions: Wrong, Wrung, Wring'
@@ -81,10 +81,10 @@ module Pronto
         it 'validates each word separately' do
           expect(lint_messages).to eq [
             '"LOOOK" might not be spelled correctly. ' \
-              'Spelling suggestions: LOO OK, LOO-OK, LOOK',
+              'Spelling suggestions: LOOK, LOGO, LOCK',
 
             '"SHOWTING" might not be spelled correctly. ' \
-              'Spelling suggestions: SHOW TING, SHOW-TING, SHOOTING'
+              'Spelling suggestions: SHOWING, SHOOTING, SHORTING'
           ]
         end
       end
@@ -98,7 +98,7 @@ module Pronto
               'Spelling suggestions: cool, Colo, coil',
 
             '"skool" might not be spelled correctly. '\
-              'Spelling suggestions: skoal, school, skill'
+              'Spelling suggestions: skoal, spool, stool'
           ]
         end
       end
@@ -126,7 +126,7 @@ module Pronto
             it 'returns the list of misspeled words' do
               expect(lint_messages).to eq [
                 '"helllo" might not be spelled correctly. ' \
-                  'Spelling suggestions: hell lo, hell-lo, hello',
+                  "Spelling suggestions: hello, hell, he'll",
 
                 '"tsetir" might not be spelled correctly. ' \
                   'Spelling suggestions: testier, tester, taster'


### PR DESCRIPTION
I added `.flatten` to the array of `ignored_words` and `only_lines_matching`.

This way we can have a more complex YAML structure and do things like:

```
able_words: &able_words
  - available
  - considerable
  - unable
  
. . . 
ignored_words:
  - *able_words
  - ignoreme
  - measwell
. . . 
```

This won't change anything in the behavior of the gem and will just result in better native YAML support.
The final list would look like:
```
. . .
ignored_words:
  - available
  - considerable
  - unable
  - ignoreme
  - measwell
. . .
```

Please consider merging this?